### PR TITLE
Upgrade NodeGit to 0.16.0. Fixes #5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "babel-polyfill": "^6.7.4",
     "commander": "^2.9.0",
     "moment": "^2.12.0",
-    "nodegit": "^0.11.9",
+    "nodegit": "^0.16.0",
     "readline-sync": "^1.4.1"
   },
   "devDependencies": {
@@ -31,6 +31,9 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-3": "^6.5.0",
     "rimraf": "^2.5.2"
+  },
+  "engines": {
+    "node": ">= 4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Node 6.x and 7.x are not well-supported by the old version of 0.11.x.

Breaking:
With this upgrade Node 0.12.x support is dropped.